### PR TITLE
[강병준] 2206

### DIFF
--- a/bangdori/2206.js
+++ b/bangdori/2206.js
@@ -1,0 +1,66 @@
+const readline = require("readline").createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+let input = [];
+
+readline
+  .on("line", function (line) {
+    input.push(line);
+  })
+  .on("close", function () {
+    /**
+     * Solution
+     */
+    const [ySize, xSize] = input[0].split(" ").map(Number);
+    const matrix = input.slice(1).map((el) => el.split("").map(Number));
+    console.log(solution(ySize, xSize, matrix));
+
+    process.exit();
+  });
+
+const DIRS = [
+  [-1, 0],
+  [1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+function solution(ySize, xSize, matrix) {
+  const visited = Array.from({ length: ySize }, () =>
+    Array.from({ length: xSize }, () => new Array(2).fill(false))
+  );
+
+  const queue = [];
+  queue.push([0, 0, 1, 0]); // y, x, isBreakWall
+  visited[0][0][0] = true;
+
+  let head = 0;
+
+  while (queue.length > head) {
+    const [y, x, dist, wall] = queue[head++];
+
+    if (y === ySize - 1 && x === xSize - 1) {
+      return dist;
+    }
+
+    for (const [cy, cx] of DIRS) {
+      const ny = y + cy;
+      const nx = x + cx;
+
+      if (ny < 0 || ny >= ySize) continue;
+      if (nx < 0 || nx >= xSize) continue;
+
+      if (matrix[ny][nx] === 1 && wall === 0 && !visited[ny][nx][1]) {
+        visited[ny][nx][1] = true;
+        queue.push([ny, nx, dist + 1, 1]);
+      } else if (matrix[ny][nx] === 0 && !visited[ny][nx][wall]) {
+        visited[ny][nx][wall] = true;
+        queue.push([ny, nx, dist + 1, wall]);
+      }
+    }
+  }
+
+  return -1;
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f1396575-b1a3-40fe-9b49-604fb1c822f1)

- `visited` 배열을 제대로 사용하지 않아서 메모리 초과가 발생함.

1. 0인 경우로 이동할 때, 이전에 뚫은 벽을 기준으로 `visited`의 값을 초기화해줘야하는데 0으로 초기화해줌
2. if 문에서 다음 이동할 값의 방문 여부를 제대로 체크하지 않음