### PR TITLE
[박무성] 2170

### DIFF
--- a/CodeVac513/P2170.java
+++ b/CodeVac513/P2170.java
@@ -1,0 +1,236 @@
+package CodeVac513;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class P2170 {
+    static int N;
+    static ArrayList<Node> nodeList = new ArrayList<Node>();
+    static int ans = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            nodeList.add(new Node(x, y));
+        }
+
+        nodeList.sort((a, b) -> {
+            if (a.x > b.x) {
+                return 1;
+            } else if (a.x < b.x) {
+                return -1;
+            }
+
+            if (a.length > b.length) {
+                return 1;
+            } else if (a.length < b.length) {
+                return -1;
+            }
+            return 0;
+        });
+
+        greedy();
+
+        bw.write(String.valueOf(ans));
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    static void greedy() {
+        int start = nodeList.get(0).x;
+        int end = nodeList.get(0).y;
+
+        for (int i = 1; i < N; i++) {
+            Node currentNode = nodeList.get(i);
+
+            if (currentNode.x > end) {
+                ans += end - start;
+                start = currentNode.x;
+                end = currentNode.y;
+            } else if (currentNode.y > end) {
+                end = currentNode.y;
+            }
+        }
+
+        ans += end - start;
+    }
+
+
+    static class Node {
+        int x, y, length;
+
+        Node(int x, int y) {
+            this.x = x;
+            this.y = y;
+            this.length = y - x;
+        }
+    }
+}
+
+//public class P2170 {
+//    static int N;
+//    static ArrayList<Node> nodeList = new ArrayList<Node>();
+//    static int ans = 0;
+//
+//    public static void main(String[] args) throws IOException {
+//        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+//        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+//        StringTokenizer st = new StringTokenizer(br.readLine());
+//        N = Integer.parseInt(st.nextToken());
+//
+//        for (int i = 0; i < N; i++) {
+//            st = new StringTokenizer(br.readLine());
+//            int x = Integer.parseInt(st.nextToken());
+//            int y = Integer.parseInt(st.nextToken());
+//            nodeList.add(new Node(x, y));
+//        }
+//
+//        nodeList.sort((a, b) -> {
+//            if (a.y < b.y) {
+//                return 1;
+//            } else if (a.y > b.y) {
+//                return -1;
+//            }
+//
+//            if (a.length > b.length) {
+//                return 1;
+//            } else if (a.length < b.length) {
+//                return -1;
+//            }
+//            return 0;
+//        });
+//
+//        greedy();
+//
+//        bw.write(String.valueOf(ans));
+//
+//        bw.flush();
+//        bw.close();
+//        br.close();
+//    }
+//
+//    static void greedy() {
+//        Node prevNode = nodeList.get(0);
+//        ans += prevNode.length;
+//
+//        for (int i = 1; i < N; i++) {
+//            Node currentNode = nodeList.get(i);
+//
+//            if (currentNode.y < prevNode.x) {
+//                // 완전히 분리된 선분
+//                ans += currentNode.length;
+//            } else if (currentNode.x < prevNode.x) {
+//                ans += Math.max(0, prevNode.x - currentNode.x);
+//            }
+//
+//            prevNode = currentNode;
+//
+//        }
+//    }
+//
+//
+//    static class Node {
+//        int x, y, length;
+//
+//        Node(int x, int y) {
+//            this.x = x;
+//            this.y = y;
+//            this.length = y - x;
+//        }
+//    }
+//}
+
+
+//public class P2170 {
+//    static int N;
+//    static ArrayList<Node> nodeList = new ArrayList<Node>();
+//    static int ans = 0;
+//
+//    public static void main(String[] args) throws IOException {
+//        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+//        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+//        StringTokenizer st = new StringTokenizer(br.readLine());
+//        N = Integer.parseInt(st.nextToken());
+//
+//        for (int i = 0; i < N; i++) {
+//            st = new StringTokenizer(br.readLine());
+//            int x = Integer.parseInt(st.nextToken());
+//            int y = Integer.parseInt(st.nextToken());
+//            nodeList.add(new Node(x, y));
+//        }
+//
+//        nodeList.sort((a, b) -> {
+//            if (a.y < b.y) {
+//                return 1;
+//            } else if (a.y > b.y) {
+//                return -1;
+//            }
+//
+//            if (a.length > b.length) {
+//                return 1;
+//            } else if (a.length < b.length) {
+//                return -1;
+//            }
+//            return 0;
+//        });
+//
+//        for (int i = 0; i < N; i++) {
+//            bw.write(nodeList.get(i).x + " " + nodeList.get(i).y);
+//            bw.write("\n");
+//        }
+//
+//        greedy();
+//
+//        bw.write(String.valueOf(ans));
+//
+//        bw.flush();
+//        bw.close();
+//        br.close();
+//    }
+//
+//    static void greedy() {
+//        Node prevNode = nodeList.get(0);
+//        for (int i = 0; i < N; i++) {
+//            Node currentNode = nodeList.get(i);
+//
+//            if (i == 0) {
+//                ans += currentNode.length;
+//                continue;
+//            }
+//
+//            if (currentNode.y < prevNode.x) {
+//                int length = currentNode.y - currentNode.x;
+//                ans += length;
+//                prevNode = currentNode;
+//                continue;
+//            }
+//
+//            if (currentNode.y <= prevNode.y) {
+//                int length = prevNode.x - currentNode.x;
+//                ans += length;
+//                prevNode = currentNode;
+//            }
+//        }
+//    }
+//
+//
+//    static class Node {
+//        int x, y, length;
+//
+//        Node(int x, int y) {
+//            this.x = x;
+//            this.y = y;
+//            this.length = y - x;
+//        }
+//    }
+//}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f4c486c5-f986-4b5b-abcd-e37c6f43b4d4)


- 처음에는 y값을 기준으로 내림차순 정렬을 했습니다. for문으로 전체를 탐색하면서 이전 선분의 범위에 다음 선분의 x가 포함되는지를 검사하며 길이를 구했습니다.
그리고 현재 선분을 이전 선분으로 설정하고 루프를 반복합니다.
=> 아래와 같은 반례가 존재합니다.
```
3
1 5
2 10
6 8
```
y기준으로 내림차순 정리하면 (2,10), (6,8), (1,5)가 될 것입니다.
그래서 ans += 8이 연산됩니다.
그 후 (6,8) 을 지나가면서 ans에 연산은 없지만 (6,8)이  prevNode로 업데이트되고, 
(1,5)에서 원래 1만 더해야할 것을 4를 더하게 되어 답이 12로 출력됩니다.

- 이런 오류를 고치고자 생각했는데, 정렬을 한 뒤 end와 start를 업데이트하는 방식으로 수정했습니다.
이 때, y를 기준으로 정렬하니 직관적이지 않고 x로 정렬을 해도 같은 풀이가 될 것 같아 x를 기준으로 수정하여 구현했습니다. 