### PR TITLE
[박무성] 1806

### DIFF
--- a/CodeVac513/P1806.java
+++ b/CodeVac513/P1806.java
@@ -1,0 +1,54 @@
+package CodeVac513;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class P1806 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int S = Integer.parseInt(st.nextToken());
+
+        int[] nums = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            nums[i] = Integer.parseInt(st.nextToken());
+        }
+
+        bw.write(String.valueOf(twoPointer(nums, S, N)));
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    static int twoPointer(int[] nums, int S, int N) {
+        int start = 0;
+        int end = 0;
+        int sum = 0;
+        int result = Integer.MAX_VALUE;
+        while (true) {
+            if (sum >= S) {
+                int ans = end - start;
+                if (ans < result)
+                    result = ans;
+                sum -= nums[start];
+                start++;
+            } else if (end == N) {
+                break;
+            } else {
+                sum += nums[end++];
+            }
+        }
+
+        if (result == Integer.MAX_VALUE)
+            return 0;
+        return result;
+    }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3c6fc699-70e5-4e29-809b-dafd6efefeaf)

- `start <= end && end < N` while문의 조건을 다음과 같이 설정했었습니다.
start는 항상 end 이하이기에 true이고, end == N이 되면 반복문을 종료했습니다.
하지만 마지막까지 탐색하고도 최소 길이를 찾기 위해서, end == N이면서 start index가 움직이는 상황이 발생할 수 있음을 확인했습니다.
