### PR TITLE
[박무성] 12015

### DIFF
--- a/CodeVac513/P12015.java
+++ b/CodeVac513/P12015.java
@@ -1,0 +1,60 @@
+package CodeVac513;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class P12015 {
+    static int N;
+    static int[] nums;
+    static int[] ans;
+
+    public static void main(String[] args) throws IOException {
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        nums = new int[N];
+        ans = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            nums[i] = Integer.parseInt(st.nextToken());
+        }
+
+        bw.write(String.valueOf(dp()));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    static int dp() {
+        ans[0] = nums[0];
+        int length = 1;
+
+        for (int i = 1; i < N; i++) {
+
+            int currentValue = nums[i];
+            if (ans[length - 1] < currentValue) {
+                length++;
+                ans[length - 1] = currentValue;
+            } else {
+                int left = 0;
+                int right = length;
+                while (left < right) {
+                    int mid = (left + right) / 2;
+
+                    if (ans[mid] < currentValue) {
+                        left = mid + 1;
+                    } else {
+                        right = mid;
+                    }
+                }
+                ans[left] = currentValue;
+            }
+        }
+        return length;
+    }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/95155ca4-5833-41b5-bee5-53d2c18a15a6)


- 먼저 백트래킹 문제인지 고민했고, 2의 백만승의 경우를 연산해야 하므로 시간초과임을 확인
- 그리디를 생각했지만 최적해를 보장하지 않는 반례가 여럿 존재함
- 부분 최적해를 저장하는 DP임을 추정.

DP로 푸는 도중에도 문제를 풀면서 3번 틀렸음.
- 먼저 메모이제이션을 위한 배열을 두고 크기는 1000001로 할당해서 수열의 i 번째 값이 index가 되도록 설정했음. 이전 최적해를 구하는 방법이 잘 생각나지 않아 바로 이전 index의 숫자와만 비교함.
-> 이전 index와만 비교하는 게 아니라 수열이 가지는 모든 숫자와 비교해야 한다는 걸 여기서 깨달음.

- 그 후에 모든 요소에 대해 검사를 하도록 코드를 수정함. 메모이제이션 크기도 비효율적임을 깨닫고 index 기반으로 동작할 수 있도록 수정함.
```
for (int i = 1; i < N; i++) {
    for (int j = 0; j < i; j++) {
        if (nums[i] > nums[j]) {
            memo[i] = Math.max(memo[i], memo[j] + 1);
        }
    }
}
```
-> N^2 복잡도를 가져서 시간 초과 발생

- 마지막으로 [블로그 풀이](https://st-lab.tistory.com/285)를 참고해서 작은 숫자를 만나면 크기 차이가 가장 작은 값과 switch 하는 방식으로 구현 시도. 수열에서 숫자를 교환하는 부분은 이분탐색을 사용하여 N * logN의 시간복잡도를 보장함.