### PR TITLE
[박무성] 2473

### DIFF
--- a/CodeVac513/P2473.java
+++ b/CodeVac513/P2473.java
@@ -1,0 +1,183 @@
+package CodeVac513;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class P2473 {
+    static long result = Long.MAX_VALUE;
+    static long[] answer = new long[3];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+        long[] nums = new long[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < N; i++) {
+            nums[i] = Long.parseLong(st.nextToken());
+        }
+
+        Arrays.sort(nums);
+
+        solve(nums, N);
+        bw.write(answer[0] + " " + answer[1] + " " + answer[2]);
+
+        bw.flush();
+        br.close();
+        bw.close();
+    }
+
+    public static void solve(long[] nums, int N) {
+        for (int i = 0; i < N - 2; i++) {
+            int start = i;
+            int mid = i + 1;
+            int end = N - 1;
+            while (mid < end) {
+                long sum = nums[start] + nums[mid] + nums[end];
+
+                if (Math.abs(sum) < result) {
+                    result = Math.abs(sum);
+                    answer[0] = nums[start];
+                    answer[1] = nums[mid];
+                    answer[2] = nums[end];
+                }
+
+                if (sum == 0) {
+                    answer[0] = nums[start];
+                    answer[1] = nums[mid];
+                    answer[2] = nums[end];
+                    return;
+                } else if (sum> 0) {
+                    end--;
+                } else {
+                    mid++;
+                }
+            }
+        }
+    }
+}
+
+//package CodeVac513;
+//
+//import java.io.*;
+//import java.math.BigInteger;
+//import java.util.Arrays;
+//import java.util.StringTokenizer;
+//
+//public class P2473 {
+//    static BigInteger result = new BigInteger("1000000001");
+//    static BigInteger[] answer = new BigInteger[3];
+//
+//    public static void main(String[] args) throws IOException {
+//        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+//        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+//        int N = Integer.parseInt(br.readLine());
+//        BigInteger[] nums = new BigInteger[N];
+//        StringTokenizer st = new StringTokenizer(br.readLine());
+//
+//        for (int i = 0; i < N; i++) {
+//            nums[i] = new BigInteger(st.nextToken());
+//        }
+//
+//        Arrays.sort(nums);
+//
+//        solve(nums, N);
+//        bw.write(answer[0].toString() + " " + answer[1].toString() + " " + answer[2].toString());
+//
+//        bw.flush();
+//        br.close();
+//        bw.close();
+//    }
+//
+//    public static void solve(BigInteger[] nums, int N) {
+//        for (int i = 0; i < N - 2; i++) {
+//            int start = i;
+//            int mid = i + 1;
+//            int end = N - 1;
+//            while (mid < end) {
+//                BigInteger sum = nums[start].add(nums[mid]).add(nums[end]);
+//
+//                if (sum.abs().compareTo(result) < 0) {
+//                    result = sum.abs();
+//                    answer[0] = nums[start];
+//                    answer[1] = nums[mid];
+//                    answer[2] = nums[end];
+//                }
+//
+//                if (sum.abs().compareTo(BigInteger.ZERO) == 0) {
+//                    answer[0] = nums[start];
+//                    answer[1] = nums[mid];
+//                    answer[2] = nums[end];
+//                    return;
+//                } else if (sum.compareTo(BigInteger.ZERO) > 0) {
+//                    end--;
+//                } else {
+//                    mid++;
+//                }
+//            }
+//        }
+//    }
+//}
+
+
+//package CodeVac513;
+//
+//import java.io.*;
+//import java.math.BigInteger;
+//import java.util.Arrays;
+//import java.util.StringTokenizer;
+//
+//public class P2473 {
+//    static BigInteger result = new BigInteger("1000000001");
+//    static BigInteger[] answer = new BigInteger[3];
+//
+//    public static void main(String[] args) throws IOException {
+//        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+//        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+//        int N = Integer.parseInt(br.readLine());
+//        BigInteger[] nums = new BigInteger[N];
+//        StringTokenizer st = new StringTokenizer(br.readLine());
+//
+//        for (int i = 0; i < N; i++) {
+//            nums[i] = new BigInteger(st.nextToken());
+//        }
+//
+//        Arrays.sort(nums);
+//
+//        solve(nums, N);
+//
+//        bw.write(result.toString() + "\n");
+//        bw.write(answer[0].toString() + " " + answer[1].toString() + " " + answer[2].toString());
+//
+//        bw.flush();
+//        br.close();
+//        bw.close();
+//    }
+//
+//    public static void solve(BigInteger[] nums, int N) {
+//
+//        for (int i = 0; i < N - 2; i++) {
+//            for (int j = i + 1; j < N - 1; j++) {
+//                for (int k = j + 1; k < N; k++) {
+//                    BigInteger sum = nums[i].add(nums[j]).add(nums[k]);
+//                    if (sum.abs().compareTo(result.abs()) < 0) {
+//                        result = sum;
+//                        answer[0] = nums[i];
+//                        answer[1] = nums[j];
+//                        answer[2] = nums[k];
+//                    }
+//
+//                    if (sum.compareTo(BigInteger.ZERO) == 0) {
+//                        result = sum;
+//                        answer[0] = nums[i];
+//                        answer[1] = nums[j];
+//                        answer[2] = nums[k];
+//                        return;
+//                    }
+//                }
+//            }
+//        }
+//    }
+//}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e2c4c8c1-0e18-4de7-9f47-cf1e20885e20)

- 틀린 풀이(브루트포스)
  1. 3개의 포인터를 활용한다.
  2. 0 ~ N - 3 범위를 i로 순회한다.
  3. 1 ~ N - 2 범위를 j로 순회한다.
  4. 2 ~ N - 1 범위를 k로 순회한다.
  5. `nums[i] + nums[j] + nums[k]` 값을 비교하며 절댓값이 가장 작을 때 업데이트한다.
  => 결국 N^3의 시간복잡도로 1초 내에 연산을 끝내기에는 어렵다.

- [블로그](https://velog.io/@hahahaa8642/%EB%B0%B1%EC%A4%80-2473%EB%B2%88-%EC%84%B8-%EC%9A%A9%EC%95%A1-JAVA-%ED%92%80%EC%9D%B4)를 참고하였다.
- 3개의 포인터 중 첫 번째는 반복문을 통해 0 ~ N - 3 범위를 순회한다.
- 두 번째와 세 번째 포인터는 각각 첫 번째 포인터의 바로 다음 index와 마지막 index를 가리킨다.
- 이분 탐색을 활용하여 sum이 0보다 크면 세 번째 포인터를 한 칸 당기고, sum이 0보다 작으면 두 번째 포인터를 한 칸 밀어준다.

- 널포인터 예외는 처음에 BigInteger를 사용해서 그런 듯하다.
(Long으로 변경하니 똑같은 로직인데 문제없이 동작한다.)