### PR TITLE
[박무성] 16139

### DIFF
--- a/CodeVac513/P16139.java
+++ b/CodeVac513/P16139.java
@@ -1,0 +1,60 @@
+package CodeVac513;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class P16139 {
+    static int[][] sum;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        String s = br.readLine();
+        int q = Integer.parseInt(br.readLine());
+        sum = new int[26][s.length() + 1];
+        for (int i = 0; i < 26; i++) {
+            Character target = (char) ('a' + i);
+            Arrays.fill(sum[i], 0);
+            calculate(s, target);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int testCase = 0; testCase < q; testCase++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            Character target = st.nextToken().charAt(0);
+            int l = Integer.parseInt(st.nextToken());
+            int r = Integer.parseInt(st.nextToken());
+            sb.append(solve(s, l, r, target)).append("\n");
+        }
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    static void calculate(String s, Character target) {
+        int index = target - 'a';
+        if (s.charAt(0) == target) {
+            sum[index][0] = 1;
+        }
+        for (int i = 1; i < s.length(); i++) {
+            sum[index][i] = sum[index][i - 1];
+            if (s.charAt(i) == target) {
+                sum[index][i] = sum[index][i - 1] + 1;
+            }
+        }
+    }
+
+    static int solve(String s, int l, int r, Character target) {
+        int index = target - 'a';
+        if (s.charAt(l) == target) {
+            return sum[index][r] - sum[index][l] + 1;
+        }
+        return sum[index][r] - sum[index][l];
+    }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ad375608-923a-4165-853a-8d1b7d72c922)

- 누적합에서 사용할 배열을 먼저 초기화를 했어야 했는데, 그 작업을 test_case를 받을 때마다 해버려서 시간초과가 발생했습니다.
- 아이디어는 26개의 알파벳에 길이 200000의 string에 대한 누적합 배열을 만들어 
5200000 크기 N + 상수 시간만큼 동작할 수 있도록 구현하는 것이었습니다.