### PR TITLE
[강병준] 1699

### DIFF
--- a/bangdori/1699.js
+++ b/bangdori/1699.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const input = fs.readFileSync("/dev/stdin").toString().trim().split("\n");
+
+const n = +input[0];
+
+const dp = Array(n + 1).fill(Infinity);
+
+dp[0] = 0;
+dp[1] = 1;
+dp[2] = 2;
+dp[3] = 3;
+
+for (let i = 4; i <= n; i++) {
+  if (Math.sqrt(i) - Math.floor(Math.sqrt(i)) === 0) {
+    dp[i] = 1;
+  } else {
+    dp[i] = i;
+  }
+
+  for (let k = 1; k < Math.sqrt(i); k++) {
+    // + 제곱수
+    dp[i] = Math.min(dp[i], dp[i - k ** 2] + 1);
+  }
+}
+
+console.log(dp[n]);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/92ce079d-d2f4-45f0-8b94-c526e9db239a)

1. n을 만들기 위한 최소항의 개수를 단순 1 ~ (n/2)까지의 반복문으로 처리해서 시간초과 발생
2. 마지막 제곱수 ~ i-1 까지하면 될 줄 알았는데 이건 그냥 틀린 것

알고보니, 점화식이 잘못되었음. 시간을 줄이기 위해서 다음과 같이 점화식을 구성해야함.

```js
for (let i = 1; i <= n; i++) {
  for (let j = 1; j * j <= i; j++) {
    dp[i] = Math.min(dp[i], dp[i - j ** 2] + 1);
  }
}
```

여기서 핵심은 `dp[i - j ** 2] +1`

이렇게 하면 O(N log N)으로 처리가능! 이번 문제에서 점화식을 대충 세우고 넘어갔는데 다음부터 점화식을 잘 세워보도록 노력해봐야겠다