### PR TITLE
[박무성] 2294

### DIFF
--- a/CodeVac513/P2294.java
+++ b/CodeVac513/P2294.java
@@ -1,0 +1,74 @@
+package CodeVac513;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class P2294 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        int[] coins = new int[n];
+        for (int i = 0; i < n; i++) {
+            coins[i] = Integer.parseInt(br.readLine());
+        }
+
+        int[] dp = new int[k + 1];
+        Arrays.fill(dp, Integer.MAX_VALUE);
+        for (int i = 0; i < n; i++) {
+            if (coins[i] > k) {
+                break;
+            }
+            dp[coins[i]] = 1;
+        }
+
+        Arrays.sort(coins);
+        for (int i = 0; i < coins[0]; i++) {
+            dp[i] = -1;
+        }
+
+        for (int i = 1; i <= k; i++) {
+            if (dp[i] == -1) {
+                continue;
+            }
+            for (int j = 0; j < n; j++) {
+                if (i >= coins[j] && dp[i - coins[j]] != -1 && dp[i - coins[j]] != Integer.MAX_VALUE) {
+                    dp[i] = Math.min(dp[i], dp[i - coins[j]] + 1);
+                }
+            }
+            if (dp[i] == Integer.MAX_VALUE) {
+                dp[i] = -1;
+            }
+        }
+
+//        for (int i = 1; i <= k; i++) {
+//            for (int j = i - 1; j > 0; j--) {
+//                if (dp[j] == -1 || dp[i - j] == -1) {
+//                    continue;
+//                }
+//                dp[i] = Math.min(dp[j] + dp[i - j], dp[i]);
+//            }
+//            if (dp[i] == 0) {
+//                dp[i] = -1;
+//            }
+//        }
+//        bw.write(String.valueOf(dp[k]));
+        if (dp[k] == Integer.MAX_VALUE || dp[k] == -1) {
+            bw.write("-1");
+        } else {
+            bw.write(String.valueOf(dp[k]));
+        }
+
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+}


### PR DESCRIPTION
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/2087b7b4-eaca-477d-b317-bb740bd01053" />

```java
        for (int i = 1; i <= k; i++) {
            for (int j = i - 1; j > 0; j--) {
                if (dp[j] == -1 || dp[i - j] == -1) {
                    continue;
                }
                dp[i] = Math.min(dp[j] + dp[i - j], dp[i]);
            }
            if (dp[i] == 0) {
                dp[i] = -1;
            }
        }
        bw.write(String.valueOf(dp[k]));
```
처음에는 위와 같이 풀려고 했습니다.
동전과는 상관없이 바텀업으로 모든 배열이 채워나가며 계산될 것을 기대했는데, 이러면 동전의 조합을 잘못 계산할 수도 있었습니다.
i, i-j로 문제를 풀려고 했으면 Math.min( {i, i-j}, { i - 1, i - j +1}, ...)과 같이 연산해야 합니다.

그래서 coins를 활용하도록 로직을 수정했습니다.

제출 상황의 배열 인덱스 예외는 k값이 동전보다 작은 경우를 고려하지 않아 발생했습니다.