### PR TITLE
[박무성] 3

### DIFF
--- a/CodeVac513/P3.java
+++ b/CodeVac513/P3.java
@@ -1,0 +1,37 @@
+package CodeVac513;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class P3 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        boolean[] used = new boolean[128];
+        String s = br.readLine();
+        int startIndex = 0;
+        int endIndex = 0;
+        int maxLength = 0;
+        while (endIndex < s.length()) {
+            char c = s.charAt(endIndex);
+            if (used[c]) {
+                used[s.charAt(startIndex)] = false;
+                startIndex++;
+            } else {
+                used[c] = true;
+                endIndex++;
+                maxLength = Math.max(maxLength, endIndex - startIndex);
+            }
+
+        }
+        System.out.println("ans = " + (maxLength));
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+
+
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dbd3ec80-5643-45e2-9f28-99567ff02912)

- 처음에는 최대 길이를 해당하는 index에 누적시키는 문제인 줄 알았는데요, 반례가 많아서 틀렸다는 걸 알았습니다.
- 투포인터로 노선을 틀었는데 공백이나 다른 문자가 들어가는 경우를 생각 안했다가, 아스키 전체를 boolean으로 검사하도록 수정했습니다.

PR 작성하면서 병준님 코드를 봤는데, set으로 검사하는 게 더 깔끔할 것 같아요... 생각을 못했네요.